### PR TITLE
This can fail on first start up, added error handle for empty case

### DIFF
--- a/zhaquirks/tuya/ts1201.py
+++ b/zhaquirks/tuya/ts1201.py
@@ -379,7 +379,10 @@ class ZosungIRBlaster(CustomDevice):
 
     seq = -1
     ir_msg_to_send = {}
-    last_learned_ir_code = t.CharacterString()
+    try:
+        last_learned_ir_code = t.CharacterString()
+    except:
+        last_learned_ir_code = ""
 
     def __init__(self, *args, **kwargs):
         """Init device."""


### PR DESCRIPTION
## Proposed change
Added an error handle on startup for TS1201 device


## Additional information
HA would crash the script as the t object was empty, this set the initial value to an empty string

## Checklist

- [x] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
