### PR TITLE
fix ts1201.py - last_learned_ir_code init error

### DIFF
--- a/zhaquirks/tuya/ts1201.py
+++ b/zhaquirks/tuya/ts1201.py
@@ -379,7 +379,7 @@ class ZosungIRBlaster(CustomDevice):
 
     seq = -1
     ir_msg_to_send = {}
-    last_learned_ir_code = t.CharacterString()
+    last_learned_ir_code = t.CharacterString('')
 
     def __init__(self, *args, **kwargs):
         """Init device."""


### PR DESCRIPTION

## Proposed change
fixes a small issue preventing quirk from loading where t.CharacterString expects a value

## Additional information
<!--
  Please include any additional information that is important to this PR.
  For example, if this PR is a potentially breaking change, mention that here.
  If this PR requires other PRs to be merged in HA Core or other projects, mention that.
  Lastly, if this PR fixes a specific issue, please include "Fixes #xxxx".
-->


## Checklist
<!--
  Put an 'x' in all boxes that apply.
  Note: You do not need to tick all boxes before creating a PR.
-->

- [x ] The changes are tested and work correctly
- [ ] `pre-commit` checks pass / the code has been formatted using Black
- [ ] Tests have been added to verify that the new code works
